### PR TITLE
Add $4 for ports and set a default value 6379

### DIFF
--- a/redis/redis-status.sh
+++ b/redis/redis-status.sh
@@ -6,7 +6,7 @@ METRIC="$2"
 SERV="$1"
 DB="$3"
 
-PORT="6379"
+PORT="${4:-6379}"
 
 if [[ -z "$1" ]]; then
     echo "Please set server"


### PR DESCRIPTION
To work with template added in repo I set a default value for PORT , because of we dont have any macro represent the port of redis that we specify in the item and we dont want to complicated the process just add to readme

> ```
> if you use specific port you have to add triggers yourself default trigger only works for 6379 ...
> ```
